### PR TITLE
Standard webapp artifact (war packaging) get the Liferay facet added 

### DIFF
--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/MavenUtil.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/MavenUtil.java
@@ -232,13 +232,6 @@ public class MavenUtil
             retval = mavenProject.getPlugin( ILiferayMavenConstants.LIFERAY_MAVEN_PLUGIN_KEY );
         }
 
-        if( retval == null )
-        {
-            retval =
-                mavenProject.getPluginManagement().getPluginsAsMap().get(
-                    ILiferayMavenConstants.LIFERAY_MAVEN_PLUGIN_KEY );
-        }
-
         return retval;
     }
 


### PR DESCRIPTION
Liferay facet should only be added on projects that declare the liferay-maven-plugin in the build section. Imagine that the parent pom is only used to set the version and default plugin properties (as it should be done right ?), what will happen to non Liferay war project ?

IMHO, when the plugin is not explicitly attached to the build lifecycle, the Liferay facet should not be added. Is there any reason you explicitly added those 235-240 lines ?   

In my case, standard webapp and Liferay plugins are children of the same parent where the liferay-maven-plugin is declared in the pluginManagement section.

Standard webapp (war artifact, but not Liferay plugins) get the Liferay facet added when I run the Maven > Update Project. 
