### PR TITLE
IDE-1707 Locate to the last child node

### DIFF
--- a/common/plugins/com.liferay.ide.ui/src/com/liferay/ide/ui/wizard/ExternalFileSelectionDialog.java
+++ b/common/plugins/com.liferay.ide.ui/src/com/liferay/ide/ui/wizard/ExternalFileSelectionDialog.java
@@ -201,7 +201,7 @@ public class ExternalFileSelectionDialog extends FilteredElementTreeSelectionDia
     {
         TreeViewer viewer = super.doCreateTreeViewer( parent, style );
 
-        viewer.setAutoExpandLevel( 3 );
+        viewer.setAutoExpandLevel( 5 );
 
         return viewer;
     }


### PR DESCRIPTION
Hi Greg,

I fixed this issue by setting the expand level to 5 as usually JSP could expand 5 levels like html/portlet/portlet_name/section_name/*.jsp.
