### PR TITLE
Use aui2.0.x tern plugin

### DIFF
--- a/jsdt/plugins/com.liferay.ide.alloy.core/plugin.xml
+++ b/jsdt/plugins/com.liferay.ide.alloy.core/plugin.xml
@@ -19,15 +19,11 @@
             name="Liferay Project Tern Adapter">
          <defaultModules>
             <module
-                  name="aui"
+                  name="aui2.0.x"
                   withDependencies="true">
             </module>
             <module
                   name="liferay"
-                  withDependencies="true">
-            </module>
-            <module
-                  name="yui"
                   withDependencies="true">
             </module>
          </defaultModules>


### PR DESCRIPTION
This PR gives the capability to use the new tern plugin aui2.0.x. Note that you need not to add yui3 because withDependencies="true" select it automaticly. 

@gamerson I have not tested, tell me if it works, thanks.