### PR TITLE
Use gradle assemble instead of gradle build

### DIFF
--- a/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/LiferayGradleProject.java
+++ b/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/LiferayGradleProject.java
@@ -107,6 +107,13 @@ public class LiferayGradleProject extends BaseLiferayProject implements IBundleP
             {
                 for( File outputFile : outputFiles )
                 {
+                	if( outputFile.getName().endsWith("javadoc.jar" ) ||
+                	    outputFile.getName().endsWith("jspc.jar" ) 	  ||
+                	    outputFile.getName().endsWith("sources.jar" ) )
+                	{
+                		continue;
+                	}
+
                     if( outputFile.getName().endsWith( ".jar" ) )
                     {
                         bundleFile = outputFile;
@@ -278,11 +285,11 @@ public class LiferayGradleProject extends BaseLiferayProject implements IBundleP
 
             if( cleanBuild )
             {
-                launcher.forTasks( "clean", "build" ).run( handler );
+                launcher.forTasks( "clean", "assemble" ).run( handler );
             }
             else
             {
-                launcher.forTasks( "build" ).run( handler );
+                launcher.forTasks( "assemble" ).run( handler );
             }
 
             handler.getResult();


### PR DESCRIPTION
Change gradle to use "assemble" instead of "build" and filter out extras files creating during sub repo build process.  This change allows Liferay owned modules located in sub repos to deploy to the Liferay Server defined in Liferay IDE and will make it easier for community contributors who want to contribute to the Liferay codebase.

@gamerson Here is the PR for the change we discussed earlier.  Let me know if you need anything else.