### PR TITLE
LPD-40802 Invalid Liferay version encountered when building a new rest-builder template module on Liferay IDE 3.10.1 through Eclipse

### DIFF
--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -27,8 +27,8 @@
     <name>Liferay IDE Parent</name>
 
     <properties>
-        <blade-latest-download-url>https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-snapshots/com/liferay/blade/com.liferay.blade.cli//7.0.2-SNAPSHOT/com.liferay.blade.cli-7.0.2-20240802.025710-4.jar</blade-latest-download-url>
-        <blade-latest-md5>f93d29d58af6fd77070289820b5cd606</blade-latest-md5>
+        <blade-latest-download-url>https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-snapshots/com/liferay/blade/com.liferay.blade.cli/7.0.2-SNAPSHOT/com.liferay.blade.cli-7.0.2-20241003.195753-5.jar</blade-latest-download-url>
+        <blade-latest-md5>2ddb007763a97f1d38a06c5bf0fd4324</blade-latest-md5>
         <blade-392-download-url>https://repository-cdn.liferay.com/nexus/content/repositories/public/com/liferay/blade/com.liferay.blade.cli/3.9.2/com.liferay.blade.cli-3.9.2.jar</blade-392-download-url>
         <blade-392-md5>08aedcb6bacc3166060d0032f9489dd1</blade-392-md5>
         <upgrade-plan-content-zip-url>https://us-east-1.linodeobjects.com/devtools-s3.liferay.com/liferay-ide-files/docs/code-upgrade-docs-20210312.zip</upgrade-plan-content-zip-url>

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/ext/ModuleExtProjectNameValidationService.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/ext/ModuleExtProjectNameValidationService.java
@@ -58,7 +58,7 @@ public class ModuleExtProjectNameValidationService extends ModuleProjectNameVali
 		}
 
 		if (CoreUtil.compareVersions(
-				Version.parseVersion(liferayWorkspaceProjectVersion), Version.parseVersion("7.0")) <= 0) {
+				CoreUtil.parseVersion(liferayWorkspaceProjectVersion), Version.parseVersion("7.0")) <= 0) {
 
 			retval = Status.createErrorStatus(
 				"Module Ext projects only work on liferay workspace which version is greater than 7.0.");


### PR DESCRIPTION
This is an update for [LPD-40802](https://liferay.atlassian.net/browse/LPD-40802).
