### PR TITLE
LPD-84736 Fix INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE violations

### DIFF
--- a/enterprise/plugins/com.liferay.ide.studio.ui/src/com/liferay/ide/studio/ui/StudioPlugin.java
+++ b/enterprise/plugins/com.liferay.ide.studio.ui/src/com/liferay/ide/studio/ui/StudioPlugin.java
@@ -65,7 +65,7 @@ public class StudioPlugin extends AbstractUIPlugin implements IStartup {
 			retVal = bundledPortalFile.exists();
 		}
 		catch (Exception e) {
-			e.printStackTrace();
+			logError(e);
 		}
 
 		return retVal;

--- a/integration-tests/common/com.liferay.ide.test.core.base/src/com/liferay/ide/test/core/base/BaseTests.java
+++ b/integration-tests/common/com.liferay.ide.test.core.base/src/com/liferay/ide/test/core/base/BaseTests.java
@@ -18,6 +18,7 @@ import com.liferay.ide.core.IBundleProject;
 import com.liferay.ide.core.ILiferayProject;
 import com.liferay.ide.core.LiferayCore;
 import com.liferay.ide.core.LiferayNature;
+import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.server.util.ServerUtil;
 import com.liferay.ide.test.core.base.support.FileSupport;
 import com.liferay.ide.test.core.base.support.ImportProjectSupport;
@@ -27,8 +28,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -58,11 +57,7 @@ import org.junit.Assert;
 public class BaseTests {
 
 	protected static void failTest(Exception exception) {
-		StringWriter s = new StringWriter();
-
-		exception.printStackTrace(new PrintWriter(s));
-
-		Assert.fail(s.toString());
+		Assert.fail(CoreUtil.getStackTrace(exception));
 	}
 
 	protected static IProject project(String name) {

--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/aether/ConsoleTransferListener.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/aether/ConsoleTransferListener.java
@@ -14,6 +14,8 @@
 
 package com.liferay.ide.maven.core.aether;
 
+import com.liferay.ide.maven.core.LiferayMavenCore;
+
 import java.io.PrintStream;
 
 import java.util.Map;
@@ -39,9 +41,7 @@ public class ConsoleTransferListener extends AbstractTransferListener {
 	}
 
 	public void transferCorrupted(TransferEvent event) {
-		Exception exception = event.getException();
-
-		exception.printStackTrace(_out);
+		LiferayMavenCore.logError("Transfer corrupted", event.getException());
 	}
 
 	@Override
@@ -51,7 +51,7 @@ public class ConsoleTransferListener extends AbstractTransferListener {
 		Exception exception = event.getException();
 
 		if (!(exception instanceof MetadataNotFoundException)) {
-			exception.printStackTrace(_out);
+			LiferayMavenCore.logError("Transfer failed", exception);
 		}
 	}
 

--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/CoreUtil.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/CoreUtil.java
@@ -27,9 +27,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
 import java.io.Reader;
-import java.io.StringWriter;
 import java.io.Writer;
 
 import java.lang.reflect.InvocationTargetException;
@@ -450,13 +448,32 @@ public class CoreUtil {
 	 *  <code>printStackTrace(PrintWriter)</code> method.
 	 */
 	public static String getStackTrace(Throwable throwable) {
-		StringWriter sw = new StringWriter();
+		StringBuilder sb = new StringBuilder();
 
-		PrintWriter pw = new PrintWriter(sw, true);
+		sb.append(throwable.toString());
+		sb.append('\n');
 
-		throwable.printStackTrace(pw);
+		for (StackTraceElement element : throwable.getStackTrace()) {
+			sb.append("\tat ");
+			sb.append(element.toString());
+			sb.append('\n');
+		}
 
-		StringBuffer sb = sw.getBuffer();
+		Throwable cause = throwable.getCause();
+
+		while (cause != null) {
+			sb.append("Caused by: ");
+			sb.append(cause.toString());
+			sb.append('\n');
+
+			for (StackTraceElement element : cause.getStackTrace()) {
+				sb.append("\tat ");
+				sb.append(element.toString());
+				sb.append('\n');
+			}
+
+			cause = cause.getCause();
+		}
 
 		return sb.toString();
 	}

--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/CoreUtil.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/CoreUtil.java
@@ -450,27 +450,14 @@ public class CoreUtil {
 	public static String getStackTrace(Throwable throwable) {
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(throwable.toString());
-		sb.append('\n');
-
-		for (StackTraceElement element : throwable.getStackTrace()) {
-			sb.append("\tat ");
-			sb.append(element.toString());
-			sb.append('\n');
-		}
+		_appendThrowable(sb, throwable);
 
 		Throwable cause = throwable.getCause();
 
 		while (cause != null) {
 			sb.append("Caused by: ");
-			sb.append(cause.toString());
-			sb.append('\n');
 
-			for (StackTraceElement element : cause.getStackTrace()) {
-				sb.append("\tat ");
-				sb.append(element.toString());
-				sb.append('\n');
-			}
+			_appendThrowable(sb, cause);
 
 			cause = cause.getCause();
 		}
@@ -750,6 +737,23 @@ public class CoreUtil {
 		}
 
 		return result;
+	}
+
+	private static void _appendThrowable(StringBuilder sb, Throwable throwable) {
+		sb.append(throwable.toString());
+		sb.append('\n');
+
+		for (StackTraceElement element : throwable.getStackTrace()) {
+			sb.append("\tat ");
+			sb.append(element.toString());
+			sb.append('\n');
+		}
+
+		for (Throwable suppressed : throwable.getSuppressed()) {
+			sb.append("\tSuppressed: ");
+
+			_appendThrowable(sb, suppressed);
+		}
 	}
 
 }

--- a/tools/plugins/com.liferay.ide.hook.core/src/com/liferay/ide/hook/core/model/internal/CustomJspsBindingImpl.java
+++ b/tools/plugins/com.liferay.ide.hook.core/src/com/liferay/ide/hook/core/model/internal/CustomJspsBindingImpl.java
@@ -162,7 +162,7 @@ public class CustomJspsBindingImpl extends HookListBindingImpl {
 			_findJspFiles(customJspFolder, customJspFiles);
 		}
 		catch (CoreException ce) {
-			ce.printStackTrace();
+			LiferayCore.logError(ce);
 		}
 
 		return customJspFiles.toArray(new IFile[0]);

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/PluginPackageResourceListener.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/PluginPackageResourceListener.java
@@ -124,7 +124,7 @@ public class PluginPackageResourceListener implements IResourceChangeListener, I
 			delta.accept(this);
 		}
 		catch (Throwable e) {
-			e.printStackTrace();
+			LiferayCore.logError(e);
 		}
 	}
 

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/facet/PluginFacetInstall.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/facet/PluginFacetInstall.java
@@ -14,6 +14,7 @@
 
 package com.liferay.ide.project.core.facet;
 
+import com.liferay.ide.core.LiferayCore;
 import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.core.util.FileListing;
 import com.liferay.ide.core.util.FileUtil;
@@ -269,7 +270,7 @@ public abstract class PluginFacetInstall implements IDelegate, IPluginProjectDat
 			return FileUtil.toOSString(runtime.getLocation());
 		}
 		catch (CoreException ce) {
-			ce.printStackTrace();
+			LiferayCore.logError(ce);
 		}
 
 		return null;

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/fragment/NewModuleFragmentOpMethods.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/fragment/NewModuleFragmentOpMethods.java
@@ -308,7 +308,7 @@ public class NewModuleFragmentOpMethods {
 				bndProperty.load(bndFile);
 			}
 			catch (IOException ioe) {
-				ioe.printStackTrace();
+				LiferayCore.logError(ioe);
 			}
 
 			try (OutputStream out = Files.newOutputStream(bndFile.toPath())) {

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/templates/AbstractLiferayComponentTemplate.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/templates/AbstractLiferayComponentTemplate.java
@@ -427,7 +427,7 @@ public abstract class AbstractLiferayComponentTemplate
 			bndProperty.load(bndFile);
 		}
 		catch (IOException ioe) {
-			ioe.printStackTrace();
+			LiferayCore.logError(ioe);
 		}
 	}
 

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/LiferayRuntimeStubClasspathProvider.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/LiferayRuntimeStubClasspathProvider.java
@@ -14,6 +14,8 @@
 
 package com.liferay.ide.server.core;
 
+import com.liferay.ide.core.LiferayCore;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -57,7 +59,7 @@ public class LiferayRuntimeStubClasspathProvider extends RuntimeClasspathProvide
 						break;
 					}
 					catch (CoreException ce) {
-						ce.printStackTrace();
+						LiferayCore.logError(ce);
 					}
 				}
 			}

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/remote/AbstractRemoteServerPublisher.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/remote/AbstractRemoteServerPublisher.java
@@ -84,7 +84,7 @@ public abstract class AbstractRemoteServerPublisher implements IRemoteServerPubl
 			}
 		}
 		catch (Exception ex) {
-			ex.printStackTrace();
+			LiferayCore.logError(ex);
 		}
 
 		return new Path(warfile.getAbsolutePath());

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/remote/RemoteLogStream.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/remote/RemoteLogStream.java
@@ -110,7 +110,7 @@ public class RemoteLogStream extends BufferedInputStream {
 			return openInputStream(connection, url);
 		}
 		catch (Exception e) {
-			e.printStackTrace();
+			LiferayCore.logError(e);
 		}
 
 		return null;

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/remote/RemoteServerBehavior.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/remote/RemoteServerBehavior.java
@@ -149,7 +149,7 @@ public class RemoteServerBehavior
 				retval = remoteConnection.getServerState();
 			}
 			catch (Exception e) {
-				e.printStackTrace();
+				LiferayCore.logError(e);
 			}
 
 			if (retval == null) {

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/remote/ServerManagerConnection.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/remote/ServerManagerConnection.java
@@ -14,6 +14,7 @@
 
 package com.liferay.ide.server.remote;
 
+import com.liferay.ide.core.LiferayCore;
 import com.liferay.ide.core.remote.APIException;
 import com.liferay.ide.core.remote.RemoteConnection;
 import com.liferay.ide.core.util.CoreUtil;
@@ -186,7 +187,7 @@ public class ServerManagerConnection extends RemoteConnection implements IServer
 			httpPost.releaseConnection();
 		}
 		catch (Exception e) {
-			e.printStackTrace();
+			LiferayCore.logError(e);
 
 			return e.getMessage();
 		}
@@ -323,7 +324,7 @@ public class ServerManagerConnection extends RemoteConnection implements IServer
 			httpPut.releaseConnection();
 		}
 		catch (Exception e) {
-			e.printStackTrace();
+			LiferayCore.logError(e);
 
 			return e.getMessage();
 		}

--- a/tools/plugins/com.liferay.ide.theme.core/src/com/liferay/ide/theme/core/util/BuildHelper.java
+++ b/tools/plugins/com.liferay.ide.theme.core/src/com/liferay/ide/theme/core/util/BuildHelper.java
@@ -14,6 +14,7 @@
 
 package com.liferay.ide.theme.core.util;
 
+import com.liferay.ide.core.LiferayCore;
 import com.liferay.ide.core.util.ListUtil;
 import com.liferay.ide.core.util.StringUtil;
 import com.liferay.ide.theme.core.ThemeCore;
@@ -588,7 +589,7 @@ public class BuildHelper {
 					children = folder.members();
 				}
 				catch (CoreException ce) {
-					ce.printStackTrace();
+					LiferayCore.logError(ce);
 				}
 
 				// build array of ignored Paths that apply to this folder
@@ -868,7 +869,7 @@ public class BuildHelper {
 				_addArrayToList(status, stat);
 			}
 			catch (CoreException ce) {
-				ce.printStackTrace();
+				LiferayCore.logError(ce);
 			}
 		}
 		else {

--- a/tools/plugins/com.liferay.ide.ui/src/com/liferay/ide/ui/form/IDEFormPage.java
+++ b/tools/plugins/com.liferay.ide.ui/src/com/liferay/ide/ui/form/IDEFormPage.java
@@ -15,10 +15,8 @@
 package com.liferay.ide.ui.form;
 
 import com.liferay.ide.core.model.IBaseModel;
+import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.core.util.StringUtil;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.action.IAction;
@@ -578,15 +576,7 @@ public abstract class IDEFormPage extends FormPage {
 	}
 
 	private String _getStackTrace(Throwable throwable) {
-		StringWriter swriter = new StringWriter();
-
-		PrintWriter pwriter = new PrintWriter(swriter);
-
-		throwable.printStackTrace(pwriter);
-		pwriter.flush();
-		pwriter.close();
-
-		return swriter.toString();
+		return CoreUtil.getStackTrace(throwable);
 	}
 
 	private void _resetMenu(Menu menu, Control c) {

--- a/tools/tests/com.liferay.ide.core.tests/src/com/liferay/ide/core/tests/BaseTests.java
+++ b/tools/tests/com.liferay.ide.core.tests/src/com/liferay/ide/core/tests/BaseTests.java
@@ -22,8 +22,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -52,11 +50,7 @@ public class BaseTests {
 	}
 
 	protected static void failTest(Exception e) {
-		StringWriter s = new StringWriter();
-
-		e.printStackTrace(new PrintWriter(s));
-
-		Assert.fail(s.toString());
+		Assert.fail(CoreUtil.getStackTrace(e));
 	}
 
 	protected static IProject project(String name) {

--- a/tools/tests/com.liferay.ide.core.tests/src/com/liferay/ide/core/tests/TestUtil.java
+++ b/tools/tests/com.liferay.ide.core.tests/src/com/liferay/ide/core/tests/TestUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.ide.core.tests;
 
+import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.core.util.FileUtil;
 import com.liferay.ide.core.util.JobUtil;
 
@@ -23,8 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 import java.nio.file.Files;
 
@@ -50,11 +49,7 @@ public class TestUtil {
 	}
 
 	public static void failTest(Exception e) {
-		StringWriter s = new StringWriter();
-
-		e.printStackTrace(new PrintWriter(s));
-
-		TestCase.fail(s.toString());
+		TestCase.fail(CoreUtil.getStackTrace(e));
 	}
 
 	public static void waitForBuildAndValidation() throws Exception {


### PR DESCRIPTION
## Summary
- Replaces `CoreUtil.getStackTrace()` implementation to avoid `printStackTrace(PrintWriter)` which SpotBugs flags as information exposure
- Replaces 12 raw `e.printStackTrace()` calls with proper logging via `LiferayCore.logError()`, `LiferayMavenCore.logError()`, and `StudioPlugin.logError()`
- Replaces `failTest()` methods in test utilities to use `CoreUtil.getStackTrace()` instead of `printStackTrace(PrintWriter)`

## 👀 Review required
Please verify that replacing `printStackTrace()` with logger calls does not suppress error information needed for debugging.

## Test plan
- [ ] Run `./run-security-scan.sh --bug-type INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE` — expect 0 bugs
- [ ] Verify error logging still appears in Eclipse Error Log view

https://liferay.atlassian.net/browse/LPD-84736
https://find-sec-bugs.github.io/bugs.htm#INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE