### PR TITLE
LPD-84739 Fix TEMPLATE_INJECTION_FREEMARKER violations

### DIFF
--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -1,2 +1,73 @@
 <FindBugsFilter>
+
+	<!--
+	TemplateOperation.execute() processes Freemarker templates whose Configuration
+	is created by TemplatesCore._createTemplateModel() which sets
+	ALLOWS_NOTHING_RESOLVER. SpotBugs cannot track the resolver through
+	the TemplateModel indirection.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.core.templates.TemplateOperation" />
+		<Method name="execute" />
+		<Bug pattern="TEMPLATE_INJECTION_FREEMARKER" />
+	</Match>
+
+	<!--
+	TemplatesCore._createTemplateModel() configures Freemarker Configuration with
+	TemplateClassResolver.ALLOWS_NOTHING_RESOLVER. SpotBugs cannot verify
+	the resolver configuration through static analysis.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.core.templates.TemplatesCore" />
+		<Method name="_createTemplateModel" />
+		<Bug pattern="TEMPLATE_INJECTION_FREEMARKER" />
+	</Match>
+
+	<!--
+	AbstractLiferayComponentTemplate.initFreeMarker() configures Freemarker
+	Configuration with TemplateClassResolver.ALLOWS_NOTHING_RESOLVER.
+	SpotBugs cannot verify the resolver configuration through static analysis.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.project.core.modules.templates.AbstractLiferayComponentTemplate" />
+		<Method name="initFreeMarker" />
+		<Bug pattern="TEMPLATE_INJECTION_FREEMARKER" />
+	</Match>
+
+	<!--
+	NewLiferayComponentPollerProcessorOperation.doExecute() inherits its
+	Freemarker Configuration from AbstractLiferayComponentTemplate.initFreeMarker()
+	which sets ALLOWS_NOTHING_RESOLVER. SpotBugs cannot track the resolver
+	through the inheritance chain.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.project.core.modules.templates.pollerprocessor.NewLiferayComponentPollerProcessorOperation" />
+		<Method name="doExecute" />
+		<Bug pattern="TEMPLATE_INJECTION_FREEMARKER" />
+	</Match>
+
+	<!--
+	NewLiferayComponentPortletActionCommandOperation.doExecute() inherits its
+	Freemarker Configuration from AbstractLiferayComponentTemplate.initFreeMarker()
+	which sets ALLOWS_NOTHING_RESOLVER. SpotBugs cannot track the resolver
+	through the inheritance chain.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.project.core.modules.templates.portletinactioncommand.NewLiferayComponentPortletActionCommandOperation" />
+		<Method name="doExecute" />
+		<Bug pattern="TEMPLATE_INJECTION_FREEMARKER" />
+	</Match>
+
+	<!--
+	NewLiferayComponentPortletFilterOperation.doExecute() inherits its
+	Freemarker Configuration from AbstractLiferayComponentTemplate.initFreeMarker()
+	which sets ALLOWS_NOTHING_RESOLVER. SpotBugs cannot track the resolver
+	through the inheritance chain.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.project.core.modules.templates.portletfilter.NewLiferayComponentPortletFilterOperation" />
+		<Method name="doExecute" />
+		<Bug pattern="TEMPLATE_INJECTION_FREEMARKER" />
+	</Match>
+
 </FindBugsFilter>

--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/templates/TemplatesCore.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/templates/TemplatesCore.java
@@ -17,6 +17,8 @@ package com.liferay.ide.core.templates;
 import com.liferay.ide.core.LiferayCore;
 import com.liferay.ide.core.util.FileUtil;
 
+import freemarker.core.TemplateClassResolver;
+
 import freemarker.template.Configuration;
 import freemarker.template.ObjectWrapper;
 
@@ -179,6 +181,7 @@ public class TemplatesCore {
 
 		config.setDirectoryForTemplateLoading(FileUtil.getFile(fileUrl));
 
+		config.setNewBuiltinClassResolver(TemplateClassResolver.ALLOWS_NOTHING_RESOLVER);
 		config.setObjectWrapper(ObjectWrapper.BEANS_WRAPPER);
 
 		templateModel.setConfig(config);

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/templates/AbstractLiferayComponentTemplate.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/templates/AbstractLiferayComponentTemplate.java
@@ -27,6 +27,8 @@ import com.liferay.ide.project.core.modules.IComponentTemplate;
 import com.liferay.ide.project.core.modules.NewLiferayComponentOp;
 import com.liferay.ide.project.core.modules.PropertyKey;
 
+import freemarker.core.TemplateClassResolver;
+
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -442,6 +444,7 @@ public abstract class AbstractLiferayComponentTemplate
 			cfg.setDirectoryForTemplateLoading(FileUtil.getFile(FileLocator.toFileURL(templateURL)));
 
 			cfg.setDefaultEncoding("UTF-8");
+			cfg.setNewBuiltinClassResolver(TemplateClassResolver.ALLOWS_NOTHING_RESOLVER);
 			cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
 		}
 		catch (IOException ioe) {


### PR DESCRIPTION
## Summary
- Configures `TemplateClassResolver.ALLOWS_NOTHING_RESOLVER` on all Freemarker `Configuration` objects to prevent template injection via the `?new()` built-in
- Fixes applied in `TemplatesCore` and `AbstractLiferayComponentTemplate` (subclasses inherit the fix)
- Adds SpotBugs exclusions for false positives where the scanner cannot verify the resolver configuration through static analysis

## 👀 Review required
Please verify that `ALLOWS_NOTHING_RESOLVER` does not break any existing Freemarker templates that may use `?new()`.

## Test plan
- [ ] Run `./run-security-scan.sh --bug-type TEMPLATE_INJECTION_FREEMARKER` — expect 0 bugs
- [ ] Verify component template generation still works (MVC Portlet, Poller Processor, Portlet Action Command, Portlet Filter)

https://liferay.atlassian.net/browse/LPD-84739
https://find-sec-bugs.github.io/bugs.htm#TEMPLATE_INJECTION_FREEMARKER