### PR TITLE
LPD-84740 Fix COMMAND_INJECTION violations

### DIFF
--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -1,12 +1,27 @@
 <FindBugsFilter>
 
-	<!-- ServerUIUtil.openInSystemExplorer executes the user-configured
-	     "system explorer" IDE preference command template. The command
-	     string is controlled by the IDE user on their own machine and
-	     is not influenced by external/untrusted input. -->
+	<!--
+	ServerUIUtil.openInSystemExplorer executes the user-configured
+	"system explorer" IDE preference command template. The command
+	string is controlled by the IDE user on their own machine and
+	is not influenced by external/untrusted input.
+	-->
 	<Match>
 		<Class name="com.liferay.ide.server.ui.util.ServerUIUtil" />
 		<Method name="openInSystemExplorer" />
+		<Bug pattern="COMMAND_INJECTION" />
+	</Match>
+
+	<!--
+	LaunchWorkspaceHandler.execute() uses ProcessBuilder with separate arguments
+	(no shell concatenation). The workspace location comes from Eclipse's
+	ChooseWorkspaceDialog and the launcher path from
+	Platform.getInstallLocation(). SpotBugs flags the tainted data flow
+	but the inputs are IDE-controlled.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.ui.workspace.LaunchWorkspaceHandler" />
+		<Method name="execute" />
 		<Bug pattern="COMMAND_INJECTION" />
 	</Match>
 

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -1,2 +1,13 @@
 <FindBugsFilter>
+
+	<!-- ServerUIUtil.openInSystemExplorer executes the user-configured
+	     "system explorer" IDE preference command template. The command
+	     string is controlled by the IDE user on their own machine and
+	     is not influenced by external/untrusted input. -->
+	<Match>
+		<Class name="com.liferay.ide.server.ui.util.ServerUIUtil" />
+		<Method name="openInSystemExplorer" />
+		<Bug pattern="COMMAND_INJECTION" />
+	</Match>
+
 </FindBugsFilter>

--- a/tools/plugins/com.liferay.ide.ui/src/com/liferay/ide/ui/workspace/LaunchWorkspaceHandler.java
+++ b/tools/plugins/com.liferay.ide.ui/src/com/liferay/ide/ui/workspace/LaunchWorkspaceHandler.java
@@ -106,9 +106,9 @@ public class LaunchWorkspaceHandler extends AbstractHandler {
 					break;
 
 				case Platform.OS_LINUX:
-					commands.add("/bin/bash");
-					commands.add("-c");
-					commands.add("''./" + launcher.getName() + " -data \"" + workspaceLocation + "\"''");
+					commands.add(new File(launchDir, launcher.getName()).getAbsolutePath());
+					commands.add("-data");
+					commands.add(workspaceLocation);
 
 					break;
 


### PR DESCRIPTION
## Summary
- Fixes `LaunchWorkspaceHandler` Linux case to use direct process execution with separate arguments instead of shell string concatenation via `/bin/bash -c`
- Adds SpotBugs exclusions for `ServerUIUtil.openInSystemExplorer` (user-configured IDE preference command) and `LaunchWorkspaceHandler` (IDE-controlled inputs via `ChooseWorkspaceDialog` and `Platform.getInstallLocation()`)

## 👀 Review required
Please verify the Linux `LaunchWorkspaceHandler` change still correctly launches a new Eclipse workspace.

## Test plan
- [ ] Run `./run-security-scan.sh --bug-type COMMAND_INJECTION` — expect 0 bugs
- [ ] Test "Launch Workspace" on Linux — verify new Eclipse instance launches with correct workspace
- [ ] Test "Open in System Explorer" on all platforms

https://liferay.atlassian.net/browse/LPD-84740
https://find-sec-bugs.github.io/bugs.htm#COMMAND_INJECTION