### PR TITLE
LPD-84745 Exclude GROOVY_SHELL false positive

### DIFF
--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -1,2 +1,16 @@
 <FindBugsFilter>
+
+	<!--
+	GroovyScriptingSupport.createGroovyShell() is an intentional developer-facing
+	Groovy script runner used by the IDE scripting console. The "untrusted
+	input" threat model does not apply — the IDE user authors and executes
+	their own scripts. Restricting the GroovyShell with a SecureASTCustomizer
+	would break this feature's intended purpose.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.scripting.core.GroovyScriptingSupport" />
+		<Method name="createGroovyShell" />
+		<Bug pattern="GROOVY_SHELL" />
+	</Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
## Summary
- Adds SpotBugs exclusion for `GroovyScriptingSupport` — this is an intentional developer-facing Groovy script runner for the IDE scripting console
- The untrusted input threat model does not apply since the IDE user authors and executes their own scripts
- Restricting the `GroovyShell` with a `SecureASTCustomizer` would break this feature's intended purpose

## 👀 Review required
Please confirm agreement that this is a legitimate false positive given the IDE threat model.

## Test plan
- [ ] Run `./run-security-scan.sh --bug-type GROOVY_SHELL` — expect 0 bugs

https://liferay.atlassian.net/browse/LPD-84745
https://find-sec-bugs.github.io/bugs.htm#GROOVY_SHELL