### PR TITLE
LPD-85892 Exclude unencrypted socket findings with justifications

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,8 +37,8 @@ cd build/com.liferay.ide.build.source.formatter && ./sf.sh
 ./run-security-scan.sh --bug-type XXE_SAXPARSER # filter by bug type
 ```
 
-### SpotBugs exclude file ordering
-`spotbugs-security-exclude.xml` is kept sorted per `.claude/rules/spotbugs-security-exclude-xml.md`. The `/sort-spotbugs-exclude` skill applies that rule.
+### SpotBugs exclude file format
+`spotbugs-security-exclude.xml` is kept formatted per `.claude/rules/spotbugs-security-exclude-xml.md`. The `/format-spotbugs-exclude` skill applies that rule.
 
 ## Architecture
 

--- a/.claude/rules/spotbugs-security-exclude-xml.md
+++ b/.claude/rules/spotbugs-security-exclude-xml.md
@@ -1,4 +1,4 @@
-# SpotBugs Exclude File Ordering
+# SpotBugs Exclude File Format
 
 **Applies to:** `spotbugs-security-exclude.xml` (and any other `<FindBugsFilter>` file in this repo).
 

--- a/.claude/rules/spotbugs-security-exclude-xml.md
+++ b/.claude/rules/spotbugs-security-exclude-xml.md
@@ -2,6 +2,43 @@
 
 **Applies to:** `spotbugs-security-exclude.xml` (and any other `<FindBugsFilter>` file in this repo).
 
+## Uniqueness
+
+Each `<Match>` block must target a single, unique finding location.
+
+**Do not use `<Or>` to combine multiple targets into one block.** When multiple methods (or other variants) on the same class need the same exclusion, write one `<Match>` per target, each with its own comment.
+
+Why: splitting makes every exclusion individually auditable and traceable to a specific call site. An `<Or>` block hides per-finding justifications behind a single shared comment and is harder to diff or review one finding at a time.
+
+**Wrong:**
+```xml
+<Match>
+    <Bug pattern="UNENCRYPTED_SOCKET" />
+    <Class name="com.example.SocketUtil" />
+    <Or>
+        <Method name="canConnect" />
+        <Method name="canConnectProxy" />
+    </Or>
+</Match>
+```
+
+**Right:**
+```xml
+<!-- Comment specific to canConnect -->
+<Match>
+    <Bug pattern="UNENCRYPTED_SOCKET" />
+    <Class name="com.example.SocketUtil" />
+    <Method name="canConnect" />
+</Match>
+
+<!-- Comment specific to canConnectProxy -->
+<Match>
+    <Bug pattern="UNENCRYPTED_SOCKET" />
+    <Class name="com.example.SocketUtil" />
+    <Method name="canConnectProxy" />
+</Match>
+```
+
 ## Block order
 
 Sort `<Match>` blocks by:
@@ -43,7 +80,9 @@ untrusted input handling, so there is no security bypass risk.
 
 ## Edge case: non-standard children
 
-If a `<Match>` uses elements other than `Bug`/`Class`/`Method` (e.g. `<Or>`, `<Field>`, `<Source>`), keep those at the end of the child list in their original relative order, and use the first `Bug`/`Class`/`Method` value (or empty string if absent) as the sort key. Flag the unusual entry to the user.
+`<Or>` is **not allowed** — see the Uniqueness section; split the entry instead.
+
+If a `<Match>` uses other non-standard elements (e.g. `<Field>`, `<Source>`), keep those at the end of the child list in their original relative order, and use the first `Bug`/`Class`/`Method` value (or empty string if absent) as the sort key. Flag the unusual entry to the user.
 
 ## Example
 

--- a/.claude/skills/format-spotbugs-exclude/SKILL.md
+++ b/.claude/skills/format-spotbugs-exclude/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: sort-spotbugs-exclude
-description: Sort `spotbugs-security-exclude.xml` (or another `<FindBugsFilter>` file in this repo) according to the rule at `.claude/rules/spotbugs-security-exclude-xml.md`. Use when the user asks to sort or normalize the SpotBugs exclude file, or when adding entries to it.
+name: format-spotbugs-exclude
+description: Format `spotbugs-security-exclude.xml` (or another `<FindBugsFilter>` file in this repo) according to the rule at `.claude/rules/spotbugs-security-exclude-xml.md`. Use when the user asks to format or normalize the SpotBugs exclude file, or when adding entries to it.
 ---
 
-# Sort SpotBugs Exclude Filter
+# Format SpotBugs Exclude Filter
 
 Apply the rule defined in `.claude/rules/spotbugs-security-exclude-xml.md` to a `<FindBugsFilter>` XML file.
 
 ## Usage
 
-- `/sort-spotbugs-exclude` — sort `spotbugs-security-exclude.xml` at the repo root
-- `/sort-spotbugs-exclude <path>` — sort the given filter file
+- `/format-spotbugs-exclude` — format `spotbugs-security-exclude.xml` at the repo root
+- `/format-spotbugs-exclude <path>` — format the given filter file
 
 ## Process
 

--- a/.claude/skills/format-spotbugs-exclude/SKILL.md
+++ b/.claude/skills/format-spotbugs-exclude/SKILL.md
@@ -14,10 +14,11 @@ Apply the rule defined in `.claude/rules/spotbugs-security-exclude-xml.md` to a 
 
 ## Process
 
-1. **Read the rule.** Read `.claude/rules/spotbugs-security-exclude-xml.md` for the canonical block order, child order, comment handling, and preservation requirements. The rule file is the source of truth — do not paraphrase it from memory.
+1. **Read the rule.** Read `.claude/rules/spotbugs-security-exclude-xml.md` for the canonical block order, child order, uniqueness requirement, comment handling, and preservation requirements. The rule file is the source of truth — do not paraphrase it from memory.
 2. **Read the target file.**
-3. **Parse** into a list of (leading-comment, `<Match>`) pairs plus any header/footer (XML declaration, `<FindBugsFilter>` open/close tags).
-4. **Reorder children** inside each `<Match>` per the rule.
-5. **Sort the pairs** per the rule.
-6. **Re-emit** the file with one blank line between entries, comments above their `<Match>`, and the original wrapper preserved.
-7. **Verify** with `git diff <path>` — the diff should be purely a reordering. No attribute or comment text changes. If anything else changed, stop and investigate.
+3. **Check for `<Or>` blocks.** Each `<Match>` must target a single finding location. If any `<Match>` contains an `<Or>` element, stop and ask the user to split it into separate entries (each new entry needs its own comment) before continuing — do not auto-split, since the per-entry comment requires human judgment.
+4. **Parse** into a list of (leading-comment, `<Match>`) pairs plus any header/footer (XML declaration, `<FindBugsFilter>` open/close tags).
+5. **Reorder children** inside each `<Match>` per the rule.
+6. **Sort the pairs** per the rule.
+7. **Re-emit** the file with one blank line between entries, comments above their `<Match>`, and the original wrapper preserved.
+8. **Verify** with `git diff <path>` — the diff should be purely a reordering. No attribute or comment text changes. If anything else changed, stop and investigate.

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -23,4 +23,40 @@
 		<Class name="com.liferay.ide.maven.core.util.DefaultMaven2OsgiConverter" />
 		<Method name="getVersion" />
 	</Match>
+
+	<!-- Skip this unencrypted socket because the Gogo OSGi console is a telnet protocol (per class Javadoc) and the server endpoint is not SSL -->
+
+	<Match>
+		<Class name="com.liferay.ide.server.core.gogo.GogoShellClient" />
+		<Method name="&lt;init&gt;" />
+		<Bug pattern="UNENCRYPTED_SOCKET" />
+	</Match>
+
+	<!-- Skip this unencrypted socket because it is a TCP reachability probe to a user-configured remote port; the wire protocol is dictated by the remote server, not the IDE -->
+
+	<Match>
+		<Class name="com.liferay.ide.server.remote.RemoteServer" />
+		<Method name="canMakeHttpConnection" />
+		<Bug pattern="UNENCRYPTED_SOCKET" />
+	</Match>
+
+	<!-- Skip these unencrypted sockets because they back the reachability probes above; sockets are bound, connected, and immediately closed without transmitting application data -->
+
+	<Match>
+		<Class name="com.liferay.ide.server.util.SocketUtil" />
+		<Or>
+			<Method name="canConnect" />
+			<Method name="canConnectProxy" />
+		</Or>
+		<Bug pattern="UNENCRYPTED_SOCKET" />
+	</Match>
+
+	<!-- Skip this unencrypted server socket because it does a local bind()-then-close to test port availability; no remote client ever connects and no data is transmitted -->
+
+	<Match>
+		<Class name="com.liferay.ide.server.util.SocketUtil" />
+		<Method name="isPortAvailable" />
+		<Bug pattern="UNENCRYPTED_SERVER_SOCKET" />
+	</Match>
+
 </FindBugsFilter>

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -48,15 +48,20 @@
 		<Method name="canMakeHttpConnection" />
 	</Match>
 
-	<!-- Skip these unencrypted sockets because they back the reachability probes above; sockets are bound, connected, and immediately closed without transmitting application data -->
+	<!-- Skip this unencrypted socket because canConnect backs the reachability probe above; the socket is bound, connected, and immediately closed without transmitting application data -->
 
 	<Match>
 		<Bug pattern="UNENCRYPTED_SOCKET" />
 		<Class name="com.liferay.ide.server.util.SocketUtil" />
-		<Or>
-			<Method name="canConnect" />
-			<Method name="canConnectProxy" />
-		</Or>
+		<Method name="canConnect" />
+	</Match>
+
+	<!-- Skip this unencrypted socket because canConnectProxy backs the reachability probe above; the socket is bound, connected, and immediately closed without transmitting application data -->
+
+	<Match>
+		<Bug pattern="UNENCRYPTED_SOCKET" />
+		<Class name="com.liferay.ide.server.util.SocketUtil" />
+		<Method name="canConnectProxy" />
 	</Match>
 
 </FindBugsFilter>

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -24,39 +24,39 @@
 		<Method name="getVersion" />
 	</Match>
 
+	<!-- Skip this unencrypted server socket because it does a local bind()-then-close to test port availability; no remote client ever connects and no data is transmitted -->
+
+	<Match>
+		<Bug pattern="UNENCRYPTED_SERVER_SOCKET" />
+		<Class name="com.liferay.ide.server.util.SocketUtil" />
+		<Method name="isPortAvailable" />
+	</Match>
+
 	<!-- Skip this unencrypted socket because the Gogo OSGi console is a telnet protocol (per class Javadoc) and the server endpoint is not SSL -->
 
 	<Match>
+		<Bug pattern="UNENCRYPTED_SOCKET" />
 		<Class name="com.liferay.ide.server.core.gogo.GogoShellClient" />
 		<Method name="&lt;init&gt;" />
-		<Bug pattern="UNENCRYPTED_SOCKET" />
 	</Match>
 
 	<!-- Skip this unencrypted socket because it is a TCP reachability probe to a user-configured remote port; the wire protocol is dictated by the remote server, not the IDE -->
 
 	<Match>
+		<Bug pattern="UNENCRYPTED_SOCKET" />
 		<Class name="com.liferay.ide.server.remote.RemoteServer" />
 		<Method name="canMakeHttpConnection" />
-		<Bug pattern="UNENCRYPTED_SOCKET" />
 	</Match>
 
 	<!-- Skip these unencrypted sockets because they back the reachability probes above; sockets are bound, connected, and immediately closed without transmitting application data -->
 
 	<Match>
+		<Bug pattern="UNENCRYPTED_SOCKET" />
 		<Class name="com.liferay.ide.server.util.SocketUtil" />
 		<Or>
 			<Method name="canConnect" />
 			<Method name="canConnectProxy" />
 		</Or>
-		<Bug pattern="UNENCRYPTED_SOCKET" />
-	</Match>
-
-	<!-- Skip this unencrypted server socket because it does a local bind()-then-close to test port availability; no remote client ever connects and no data is transmitted -->
-
-	<Match>
-		<Class name="com.liferay.ide.server.util.SocketUtil" />
-		<Method name="isPortAvailable" />
-		<Bug pattern="UNENCRYPTED_SERVER_SOCKET" />
 	</Match>
 
 </FindBugsFilter>


### PR DESCRIPTION
Subtask of [LPD-84738](https://liferay.atlassian.net/browse/LPD-84738). None of the 6 unencrypted-socket findings warrant switching to `SSLSocket`/`SSLServerSocket`; per-finding justification is inline as a comment on each `<Match>`.