### PR TITLE
LPD-89665 Exclude GROOVY_SHELL finding with justification

### DIFF
--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -1,5 +1,13 @@
 <FindBugsFilter>
 
+	<!-- Only loads .groovy scripts bundled in the plugin, not user input -->
+
+	<Match>
+		<Bug pattern="GROOVY_SHELL" />
+		<Class name="com.liferay.ide.scripting.core.GroovyScriptingSupport" />
+		<Method name="newInstanceFromFile" />
+	</Match>
+
 	<!-- False positive: hard coded password is the default for a testcase only -->
 
 	<Match>


### PR DESCRIPTION
The method is only reachable via `WorkflowValidationProxy`, which loads one of three `.groovy` scripts shipped inside the `com.liferay.ide.kaleo.core` OSGi bundle. No user, workspace, or remote input controls the path or contents.