### PR TITLE
LPD-84732 Fix XXE vulnerabilities across all modules

### DIFF
--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/NewMavenPluginProjectProvider.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/NewMavenPluginProjectProvider.java
@@ -17,6 +17,7 @@ package com.liferay.ide.maven.core;
 import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.core.util.FileUtil;
 import com.liferay.ide.core.util.ListUtil;
+import com.liferay.ide.core.util.SecureXMLFactoryUtil;
 import com.liferay.ide.core.util.StringUtil;
 import com.liferay.ide.project.core.IPortletFramework;
 import com.liferay.ide.project.core.NewLiferayProjectProvider;
@@ -217,7 +218,7 @@ public class NewMavenPluginProjectProvider
 
 						FileUtils.copyFile(settingsXmlFile, backupFile);
 
-						DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+						DocumentBuilderFactory docFactory = SecureXMLFactoryUtil.newDocumentBuilderFactory();
 
 						DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
 
@@ -227,7 +228,7 @@ public class NewMavenPluginProjectProvider
 							createNewLiferayProfileNode(pomDocument, newProfile);
 						}
 
-						TransformerFactory transformerFactory = TransformerFactory.newInstance();
+						TransformerFactory transformerFactory = SecureXMLFactoryUtil.newTransformerFactory();
 
 						Transformer transformer = transformerFactory.newTransformer();
 
@@ -248,7 +249,7 @@ public class NewMavenPluginProjectProvider
 					activeProfiles, op.getNewLiferayProfiles(), ProfileLocation.projectPom);
 
 				try {
-					DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+					DocumentBuilderFactory docFactory = SecureXMLFactoryUtil.newDocumentBuilderFactory();
 
 					DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
 
@@ -258,7 +259,7 @@ public class NewMavenPluginProjectProvider
 						createNewLiferayProfileNode(pomDocument, newProfile);
 					}
 
-					TransformerFactory transformerFactory = TransformerFactory.newInstance();
+					TransformerFactory transformerFactory = SecureXMLFactoryUtil.newTransformerFactory();
 
 					Transformer transformer = transformerFactory.newTransformer();
 

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -137,13 +137,13 @@
 	</Match>
 
 	<!--
-	AbstractDefaultHandler.getFactory() uses SecureXMLFactoryUtil.newSAXParserFactory()
-	which disables external entity processing. SpotBugs cannot track security
-	features set inside the utility method.
+	AbstractDefaultHandler routes all SAX parsing through SecureXMLFactoryUtil.newSAXParserFactory(),
+	which disables external entity processing. SpotBugs flags the SAXParser.parse(...) call site
+	(parseContents) rather than the factory construction (getFactory), and cannot track security
+	features set inside the utility method, so this exclusion covers the whole class.
 	-->
 	<Match>
 		<Class name="com.liferay.ide.core.AbstractDefaultHandler" />
-		<Method name="getFactory" />
 		<Bug pattern="XXE_SAXPARSER" />
 	</Match>
 

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -136,4 +136,149 @@
 		<Method name="canConnectProxy" />
 	</Match>
 
+	<!--
+	AbstractDefaultHandler.getFactory() uses SecureXMLFactoryUtil.newSAXParserFactory()
+	which disables external entity processing. SpotBugs cannot track security
+	features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.core.AbstractDefaultHandler" />
+		<Method name="getFactory" />
+		<Bug pattern="XXE_SAXPARSER" />
+	</Match>
+
+	<!--
+	FileUtil.readXML() uses SecureXMLFactoryUtil.newDocumentBuilderFactory()
+	which disables external entity processing. SpotBugs cannot track security
+	features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.core.util.FileUtil" />
+		<Method name="readXML" />
+		<Bug pattern="XXE_DOCUMENT" />
+	</Match>
+
+	<!--
+	FileUtil.readXMLFile() uses SecureXMLFactoryUtil.newDocumentBuilderFactory()
+	which disables external entity processing. SpotBugs cannot track security
+	features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.core.util.FileUtil" />
+		<Method name="readXMLFile" />
+		<Bug pattern="XXE_DOCUMENT" />
+	</Match>
+
+	<!--
+	FileUtil.writeXml() uses SecureXMLFactoryUtil.newTransformerFactory()
+	which sets FEATURE_SECURE_PROCESSING, ACCESS_EXTERNAL_DTD="", and
+	ACCESS_EXTERNAL_STYLESHEET="". SpotBugs cannot track these settings.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.core.util.FileUtil" />
+		<Method name="writeXml" />
+		<Bug pattern="XXE_XSLT_TRANSFORM_FACTORY" />
+	</Match>
+
+	<!--
+	PropertiesUtil._getLanguageFileInfo() uses a SAXParser from the static
+	_saxParserFactory field initialized via SecureXMLFactoryUtil.newSAXParserFactory().
+	SpotBugs cannot track security features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.core.util.PropertiesUtil" />
+		<Method name="_getLanguageFileInfo" />
+		<Bug pattern="XXE_SAXPARSER" />
+	</Match>
+
+	<!--
+	PropertiesUtil._getResourceNodeInfo() uses a SAXParser from the static
+	_saxParserFactory field initialized via SecureXMLFactoryUtil.newSAXParserFactory().
+	SpotBugs cannot track security features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.core.util.PropertiesUtil" />
+		<Method name="_getResourceNodeInfo" />
+		<Bug pattern="XXE_SAXPARSER" />
+	</Match>
+
+	<!--
+	StrutsActionPathPossibleValuesCacheService.getPossibleValuesForPath() uses
+	SecureXMLFactoryUtil.newDocumentBuilderFactory(). SpotBugs cannot track
+	security features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.hook.core.model.internal.StrutsActionPathPossibleValuesCacheService" />
+		<Method name="getPossibleValuesForPath" />
+		<Bug pattern="XXE_DOCUMENT" />
+	</Match>
+
+	<!--
+	NewMavenPluginProjectProvider.createNewProject() uses
+	SecureXMLFactoryUtil.newDocumentBuilderFactory() and
+	SecureXMLFactoryUtil.newTransformerFactory(). SpotBugs cannot track
+	security features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.maven.core.NewMavenPluginProjectProvider" />
+		<Method name="createNewProject" />
+		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
+	</Match>
+
+	<!--
+	PortletModelUtil.printDocument() uses SecureXMLFactoryUtil.newTransformerFactory()
+	which sets FEATURE_SECURE_PROCESSING, ACCESS_EXTERNAL_DTD="", and
+	ACCESS_EXTERNAL_STYLESHEET="". SpotBugs cannot track these settings.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.portlet.core.util.PortletModelUtil" />
+		<Method name="printDocument" />
+		<Bug pattern="XXE_XSLT_TRANSFORM_FACTORY" />
+	</Match>
+
+	<!--
+	AbstractPortalBundle.getHttpPortValue() uses
+	SecureXMLFactoryUtil.newDocumentBuilderFactory(). SpotBugs cannot track
+	security features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.server.core.portal.AbstractPortalBundle" />
+		<Method name="getHttpPortValue" />
+		<Bug pattern="XXE_DOCUMENT" />
+	</Match>
+
+	<!--
+	PortalJBossBundle._setHttpPortValue() uses
+	SecureXMLFactoryUtil.newDocumentBuilderFactory() and
+	SecureXMLFactoryUtil.newTransformerFactory(). SpotBugs cannot track
+	security features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.server.core.portal.PortalJBossBundle" />
+		<Method name="_setHttpPortValue" />
+		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
+	</Match>
+
+	<!--
+	PortalTomcatBundle._setHttpPortValue() uses
+	SecureXMLFactoryUtil.newDocumentBuilderFactory() and
+	SecureXMLFactoryUtil.newTransformerFactory(). SpotBugs cannot track
+	security features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.server.core.portal.PortalTomcatBundle" />
+		<Method name="_setHttpPortValue" />
+		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
+	</Match>
+
+	<!--
+	ServerUtil.getFilters() uses SecureXMLFactoryUtil.newDocumentBuilderFactory().
+	SpotBugs cannot track security features set inside the utility method.
+	-->
+	<Match>
+		<Class name="com.liferay.ide.server.util.ServerUtil" />
+		<Method name="getFilters" />
+		<Bug pattern="XXE_DOCUMENT" />
+	</Match>
+
 </FindBugsFilter>

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -136,11 +136,7 @@
 		<Method name="canConnectProxy" />
 	</Match>
 
-	<!--
-	FileUtil.readXML() uses SecureXMLFactoryUtil.newDocumentBuilderFactory()
-	which disables external entity processing. SpotBugs cannot track security
-	features set inside the utility method.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
@@ -148,11 +144,7 @@
 		<Method name="readXML" />
 	</Match>
 
-	<!--
-	FileUtil.readXMLFile() uses SecureXMLFactoryUtil.newDocumentBuilderFactory()
-	which disables external entity processing. SpotBugs cannot track security
-	features set inside the utility method.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
@@ -160,11 +152,7 @@
 		<Method name="readXMLFile" />
 	</Match>
 
-	<!--
-	StrutsActionPathPossibleValuesCacheService.getPossibleValuesForPath() uses
-	SecureXMLFactoryUtil.newDocumentBuilderFactory(). SpotBugs cannot track
-	security features set inside the utility method.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
@@ -172,11 +160,7 @@
 		<Method name="getPossibleValuesForPath" />
 	</Match>
 
-	<!--
-	AbstractPortalBundle.getHttpPortValue() uses
-	SecureXMLFactoryUtil.newDocumentBuilderFactory(). SpotBugs cannot track
-	security features set inside the utility method.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
@@ -184,10 +168,7 @@
 		<Method name="getHttpPortValue" />
 	</Match>
 
-	<!--
-	ServerUtil.getServletFilterNames() uses SecureXMLFactoryUtil.newDocumentBuilderFactory().
-	SpotBugs cannot track security features set inside the utility method.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
@@ -195,12 +176,7 @@
 		<Method name="getServletFilterNames" />
 	</Match>
 
-	<!--
-	NewMavenPluginProjectProvider.createNewProject() uses
-	SecureXMLFactoryUtil.newDocumentBuilderFactory() and
-	SecureXMLFactoryUtil.newTransformerFactory(). SpotBugs cannot track
-	security features set inside the utility method.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
@@ -208,12 +184,7 @@
 		<Method name="createNewProject" />
 	</Match>
 
-	<!--
-	PortalJBossBundle._setHttpPortValue() uses
-	SecureXMLFactoryUtil.newDocumentBuilderFactory() and
-	SecureXMLFactoryUtil.newTransformerFactory(). SpotBugs cannot track
-	security features set inside the utility method.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
@@ -221,12 +192,7 @@
 		<Method name="_setHttpPortValue" />
 	</Match>
 
-	<!--
-	PortalTomcatBundle._setHttpPortValue() uses
-	SecureXMLFactoryUtil.newDocumentBuilderFactory() and
-	SecureXMLFactoryUtil.newTransformerFactory(). SpotBugs cannot track
-	security features set inside the utility method.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
@@ -234,23 +200,14 @@
 		<Method name="_setHttpPortValue" />
 	</Match>
 
-	<!--
-	AbstractDefaultHandler routes all SAX parsing through SecureXMLFactoryUtil.newSAXParserFactory(),
-	which disables external entity processing. SpotBugs flags the SAXParser.parse(...) call site
-	(parseContents) rather than the factory construction (getFactory), and cannot track security
-	features set inside the utility method, so this exclusion covers the whole class.
-	-->
+	<!-- SAXParser via SecureXMLFactoryUtil; class-wide because SpotBugs flags subclass .parse() call sites -->
 
 	<Match>
 		<Bug pattern="XXE_SAXPARSER" />
 		<Class name="com.liferay.ide.core.AbstractDefaultHandler" />
 	</Match>
 
-	<!--
-	PropertiesUtil._getLanguageFileInfo() uses a SAXParser from the static
-	_saxParserFactory field initialized via SecureXMLFactoryUtil.newSAXParserFactory().
-	SpotBugs cannot track security features set inside the utility method.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_SAXPARSER" />
@@ -258,11 +215,7 @@
 		<Method name="_getLanguageFileInfo" />
 	</Match>
 
-	<!--
-	PropertiesUtil._getResourceNodeInfo() uses a SAXParser from the static
-	_saxParserFactory field initialized via SecureXMLFactoryUtil.newSAXParserFactory().
-	SpotBugs cannot track security features set inside the utility method.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_SAXPARSER" />
@@ -270,11 +223,7 @@
 		<Method name="_getResourceNodeInfo" />
 	</Match>
 
-	<!--
-	FileUtil.writeXml() uses SecureXMLFactoryUtil.newTransformerFactory()
-	which sets FEATURE_SECURE_PROCESSING, ACCESS_EXTERNAL_DTD="", and
-	ACCESS_EXTERNAL_STYLESHEET="". SpotBugs cannot track these settings.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_XSLT_TRANSFORM_FACTORY" />
@@ -282,11 +231,7 @@
 		<Method name="writeXml" />
 	</Match>
 
-	<!--
-	PortletModelUtil.printDocument() uses SecureXMLFactoryUtil.newTransformerFactory()
-	which sets FEATURE_SECURE_PROCESSING, ACCESS_EXTERNAL_DTD="", and
-	ACCESS_EXTERNAL_STYLESHEET="". SpotBugs cannot track these settings.
-	-->
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
 
 	<Match>
 		<Bug pattern="XXE_XSLT_TRANSFORM_FACTORY" />

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -141,6 +141,7 @@
 	which disables external entity processing. SpotBugs cannot track security
 	features set inside the utility method.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
 		<Class name="com.liferay.ide.core.util.FileUtil" />
@@ -152,6 +153,7 @@
 	which disables external entity processing. SpotBugs cannot track security
 	features set inside the utility method.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
 		<Class name="com.liferay.ide.core.util.FileUtil" />
@@ -163,6 +165,7 @@
 	SecureXMLFactoryUtil.newDocumentBuilderFactory(). SpotBugs cannot track
 	security features set inside the utility method.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
 		<Class name="com.liferay.ide.hook.core.model.internal.StrutsActionPathPossibleValuesCacheService" />
@@ -174,6 +177,7 @@
 	SecureXMLFactoryUtil.newDocumentBuilderFactory(). SpotBugs cannot track
 	security features set inside the utility method.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
 		<Class name="com.liferay.ide.server.core.portal.AbstractPortalBundle" />
@@ -184,6 +188,7 @@
 	ServerUtil.getServletFilterNames() uses SecureXMLFactoryUtil.newDocumentBuilderFactory().
 	SpotBugs cannot track security features set inside the utility method.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
 		<Class name="com.liferay.ide.server.util.ServerUtil" />
@@ -196,6 +201,7 @@
 	SecureXMLFactoryUtil.newTransformerFactory(). SpotBugs cannot track
 	security features set inside the utility method.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
 		<Class name="com.liferay.ide.maven.core.NewMavenPluginProjectProvider" />
@@ -208,6 +214,7 @@
 	SecureXMLFactoryUtil.newTransformerFactory(). SpotBugs cannot track
 	security features set inside the utility method.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
 		<Class name="com.liferay.ide.server.core.portal.PortalJBossBundle" />
@@ -220,6 +227,7 @@
 	SecureXMLFactoryUtil.newTransformerFactory(). SpotBugs cannot track
 	security features set inside the utility method.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
 		<Class name="com.liferay.ide.server.core.portal.PortalTomcatBundle" />
@@ -232,6 +240,7 @@
 	(parseContents) rather than the factory construction (getFactory), and cannot track security
 	features set inside the utility method, so this exclusion covers the whole class.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_SAXPARSER" />
 		<Class name="com.liferay.ide.core.AbstractDefaultHandler" />
@@ -242,6 +251,7 @@
 	_saxParserFactory field initialized via SecureXMLFactoryUtil.newSAXParserFactory().
 	SpotBugs cannot track security features set inside the utility method.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_SAXPARSER" />
 		<Class name="com.liferay.ide.core.util.PropertiesUtil" />
@@ -253,6 +263,7 @@
 	_saxParserFactory field initialized via SecureXMLFactoryUtil.newSAXParserFactory().
 	SpotBugs cannot track security features set inside the utility method.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_SAXPARSER" />
 		<Class name="com.liferay.ide.core.util.PropertiesUtil" />
@@ -264,6 +275,7 @@
 	which sets FEATURE_SECURE_PROCESSING, ACCESS_EXTERNAL_DTD="", and
 	ACCESS_EXTERNAL_STYLESHEET="". SpotBugs cannot track these settings.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_XSLT_TRANSFORM_FACTORY" />
 		<Class name="com.liferay.ide.core.util.FileUtil" />
@@ -275,6 +287,7 @@
 	which sets FEATURE_SECURE_PROCESSING, ACCESS_EXTERNAL_DTD="", and
 	ACCESS_EXTERNAL_STYLESHEET="". SpotBugs cannot track these settings.
 	-->
+
 	<Match>
 		<Bug pattern="XXE_XSLT_TRANSFORM_FACTORY" />
 		<Class name="com.liferay.ide.portlet.core.util.PortletModelUtil" />

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -137,25 +137,14 @@
 	</Match>
 
 	<!--
-	AbstractDefaultHandler routes all SAX parsing through SecureXMLFactoryUtil.newSAXParserFactory(),
-	which disables external entity processing. SpotBugs flags the SAXParser.parse(...) call site
-	(parseContents) rather than the factory construction (getFactory), and cannot track security
-	features set inside the utility method, so this exclusion covers the whole class.
-	-->
-	<Match>
-		<Class name="com.liferay.ide.core.AbstractDefaultHandler" />
-		<Bug pattern="XXE_SAXPARSER" />
-	</Match>
-
-	<!--
 	FileUtil.readXML() uses SecureXMLFactoryUtil.newDocumentBuilderFactory()
 	which disables external entity processing. SpotBugs cannot track security
 	features set inside the utility method.
 	-->
 	<Match>
+		<Bug pattern="XXE_DOCUMENT" />
 		<Class name="com.liferay.ide.core.util.FileUtil" />
 		<Method name="readXML" />
-		<Bug pattern="XXE_DOCUMENT" />
 	</Match>
 
 	<!--
@@ -164,42 +153,9 @@
 	features set inside the utility method.
 	-->
 	<Match>
+		<Bug pattern="XXE_DOCUMENT" />
 		<Class name="com.liferay.ide.core.util.FileUtil" />
 		<Method name="readXMLFile" />
-		<Bug pattern="XXE_DOCUMENT" />
-	</Match>
-
-	<!--
-	FileUtil.writeXml() uses SecureXMLFactoryUtil.newTransformerFactory()
-	which sets FEATURE_SECURE_PROCESSING, ACCESS_EXTERNAL_DTD="", and
-	ACCESS_EXTERNAL_STYLESHEET="". SpotBugs cannot track these settings.
-	-->
-	<Match>
-		<Class name="com.liferay.ide.core.util.FileUtil" />
-		<Method name="writeXml" />
-		<Bug pattern="XXE_XSLT_TRANSFORM_FACTORY" />
-	</Match>
-
-	<!--
-	PropertiesUtil._getLanguageFileInfo() uses a SAXParser from the static
-	_saxParserFactory field initialized via SecureXMLFactoryUtil.newSAXParserFactory().
-	SpotBugs cannot track security features set inside the utility method.
-	-->
-	<Match>
-		<Class name="com.liferay.ide.core.util.PropertiesUtil" />
-		<Method name="_getLanguageFileInfo" />
-		<Bug pattern="XXE_SAXPARSER" />
-	</Match>
-
-	<!--
-	PropertiesUtil._getResourceNodeInfo() uses a SAXParser from the static
-	_saxParserFactory field initialized via SecureXMLFactoryUtil.newSAXParserFactory().
-	SpotBugs cannot track security features set inside the utility method.
-	-->
-	<Match>
-		<Class name="com.liferay.ide.core.util.PropertiesUtil" />
-		<Method name="_getResourceNodeInfo" />
-		<Bug pattern="XXE_SAXPARSER" />
 	</Match>
 
 	<!--
@@ -208,9 +164,30 @@
 	security features set inside the utility method.
 	-->
 	<Match>
+		<Bug pattern="XXE_DOCUMENT" />
 		<Class name="com.liferay.ide.hook.core.model.internal.StrutsActionPathPossibleValuesCacheService" />
 		<Method name="getPossibleValuesForPath" />
+	</Match>
+
+	<!--
+	AbstractPortalBundle.getHttpPortValue() uses
+	SecureXMLFactoryUtil.newDocumentBuilderFactory(). SpotBugs cannot track
+	security features set inside the utility method.
+	-->
+	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
+		<Class name="com.liferay.ide.server.core.portal.AbstractPortalBundle" />
+		<Method name="getHttpPortValue" />
+	</Match>
+
+	<!--
+	ServerUtil.getServletFilterNames() uses SecureXMLFactoryUtil.newDocumentBuilderFactory().
+	SpotBugs cannot track security features set inside the utility method.
+	-->
+	<Match>
+		<Bug pattern="XXE_DOCUMENT" />
+		<Class name="com.liferay.ide.server.util.ServerUtil" />
+		<Method name="getServletFilterNames" />
 	</Match>
 
 	<!--
@@ -220,31 +197,9 @@
 	security features set inside the utility method.
 	-->
 	<Match>
+		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
 		<Class name="com.liferay.ide.maven.core.NewMavenPluginProjectProvider" />
 		<Method name="createNewProject" />
-		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
-	</Match>
-
-	<!--
-	PortletModelUtil.printDocument() uses SecureXMLFactoryUtil.newTransformerFactory()
-	which sets FEATURE_SECURE_PROCESSING, ACCESS_EXTERNAL_DTD="", and
-	ACCESS_EXTERNAL_STYLESHEET="". SpotBugs cannot track these settings.
-	-->
-	<Match>
-		<Class name="com.liferay.ide.portlet.core.util.PortletModelUtil" />
-		<Method name="printDocument" />
-		<Bug pattern="XXE_XSLT_TRANSFORM_FACTORY" />
-	</Match>
-
-	<!--
-	AbstractPortalBundle.getHttpPortValue() uses
-	SecureXMLFactoryUtil.newDocumentBuilderFactory(). SpotBugs cannot track
-	security features set inside the utility method.
-	-->
-	<Match>
-		<Class name="com.liferay.ide.server.core.portal.AbstractPortalBundle" />
-		<Method name="getHttpPortValue" />
-		<Bug pattern="XXE_DOCUMENT" />
 	</Match>
 
 	<!--
@@ -254,9 +209,9 @@
 	security features set inside the utility method.
 	-->
 	<Match>
+		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
 		<Class name="com.liferay.ide.server.core.portal.PortalJBossBundle" />
 		<Method name="_setHttpPortValue" />
-		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
 	</Match>
 
 	<!--
@@ -266,19 +221,64 @@
 	security features set inside the utility method.
 	-->
 	<Match>
+		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
 		<Class name="com.liferay.ide.server.core.portal.PortalTomcatBundle" />
 		<Method name="_setHttpPortValue" />
-		<Bug pattern="XXE_DOCUMENT,XXE_XSLT_TRANSFORM_FACTORY" />
 	</Match>
 
 	<!--
-	ServerUtil.getServletFilterNames() uses SecureXMLFactoryUtil.newDocumentBuilderFactory().
+	AbstractDefaultHandler routes all SAX parsing through SecureXMLFactoryUtil.newSAXParserFactory(),
+	which disables external entity processing. SpotBugs flags the SAXParser.parse(...) call site
+	(parseContents) rather than the factory construction (getFactory), and cannot track security
+	features set inside the utility method, so this exclusion covers the whole class.
+	-->
+	<Match>
+		<Bug pattern="XXE_SAXPARSER" />
+		<Class name="com.liferay.ide.core.AbstractDefaultHandler" />
+	</Match>
+
+	<!--
+	PropertiesUtil._getLanguageFileInfo() uses a SAXParser from the static
+	_saxParserFactory field initialized via SecureXMLFactoryUtil.newSAXParserFactory().
 	SpotBugs cannot track security features set inside the utility method.
 	-->
 	<Match>
-		<Class name="com.liferay.ide.server.util.ServerUtil" />
-		<Method name="getServletFilterNames" />
-		<Bug pattern="XXE_DOCUMENT" />
+		<Bug pattern="XXE_SAXPARSER" />
+		<Class name="com.liferay.ide.core.util.PropertiesUtil" />
+		<Method name="_getLanguageFileInfo" />
+	</Match>
+
+	<!--
+	PropertiesUtil._getResourceNodeInfo() uses a SAXParser from the static
+	_saxParserFactory field initialized via SecureXMLFactoryUtil.newSAXParserFactory().
+	SpotBugs cannot track security features set inside the utility method.
+	-->
+	<Match>
+		<Bug pattern="XXE_SAXPARSER" />
+		<Class name="com.liferay.ide.core.util.PropertiesUtil" />
+		<Method name="_getResourceNodeInfo" />
+	</Match>
+
+	<!--
+	FileUtil.writeXml() uses SecureXMLFactoryUtil.newTransformerFactory()
+	which sets FEATURE_SECURE_PROCESSING, ACCESS_EXTERNAL_DTD="", and
+	ACCESS_EXTERNAL_STYLESHEET="". SpotBugs cannot track these settings.
+	-->
+	<Match>
+		<Bug pattern="XXE_XSLT_TRANSFORM_FACTORY" />
+		<Class name="com.liferay.ide.core.util.FileUtil" />
+		<Method name="writeXml" />
+	</Match>
+
+	<!--
+	PortletModelUtil.printDocument() uses SecureXMLFactoryUtil.newTransformerFactory()
+	which sets FEATURE_SECURE_PROCESSING, ACCESS_EXTERNAL_DTD="", and
+	ACCESS_EXTERNAL_STYLESHEET="". SpotBugs cannot track these settings.
+	-->
+	<Match>
+		<Bug pattern="XXE_XSLT_TRANSFORM_FACTORY" />
+		<Class name="com.liferay.ide.portlet.core.util.PortletModelUtil" />
+		<Method name="printDocument" />
 	</Match>
 
 </FindBugsFilter>

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -272,12 +272,12 @@
 	</Match>
 
 	<!--
-	ServerUtil.getFilters() uses SecureXMLFactoryUtil.newDocumentBuilderFactory().
+	ServerUtil.getServletFilterNames() uses SecureXMLFactoryUtil.newDocumentBuilderFactory().
 	SpotBugs cannot track security features set inside the utility method.
 	-->
 	<Match>
 		<Class name="com.liferay.ide.server.util.ServerUtil" />
-		<Method name="getFilters" />
+		<Method name="getServletFilterNames" />
 		<Bug pattern="XXE_DOCUMENT" />
 	</Match>
 

--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/AbstractDefaultHandler.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/AbstractDefaultHandler.java
@@ -14,6 +14,7 @@
 
 package com.liferay.ide.core;
 
+import com.liferay.ide.core.util.SecureXMLFactoryUtil;
 import com.liferay.ide.core.util.StringPool;
 
 import java.io.IOException;
@@ -92,7 +93,7 @@ public abstract class AbstractDefaultHandler extends DefaultHandler {
 				return fFactory;
 			}
 
-			fFactory = SAXParserFactory.newInstance();
+			fFactory = SecureXMLFactoryUtil.newSAXParserFactory();
 
 			fFactory.setNamespaceAware(true);
 		}

--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/FileUtil.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/FileUtil.java
@@ -1001,7 +1001,7 @@ public class FileUtil {
 	}
 
 	public static Document readXML(InputStream inputStream, EntityResolver resolver, ErrorHandler error) {
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilderFactory dbf = SecureXMLFactoryUtil.newDocumentBuilderFactory();
 
 		DocumentBuilder db;
 
@@ -1038,7 +1038,7 @@ public class FileUtil {
 	}
 
 	public static Document readXMLFile(File file, EntityResolver resolver) {
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilderFactory dbf = SecureXMLFactoryUtil.newDocumentBuilderFactory();
 
 		DocumentBuilder db;
 
@@ -1281,7 +1281,7 @@ public class FileUtil {
 	}
 
 	public static String writeXml(Document document) throws Exception {
-		TransformerFactory tf = TransformerFactory.newInstance();
+		TransformerFactory tf = SecureXMLFactoryUtil.newTransformerFactory();
 
 		Transformer transformer = tf.newTransformer();
 

--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/PropertiesUtil.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/PropertiesUtil.java
@@ -800,7 +800,7 @@ public class PropertiesUtil {
 		return false;
 	}
 
-	private static final SAXParserFactory _saxParserFactory = SAXParserFactory.newInstance();
+	private static final SAXParserFactory _saxParserFactory = SecureXMLFactoryUtil.newSAXParserFactory();
 	private static LanguageFileInfo _tmpLanguageFileInfo = null;
 	private static ResourceNodeInfo _tmpResourceNodeInfo = null;
 

--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/SecureXMLFactoryUtil.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/SecureXMLFactoryUtil.java
@@ -31,7 +31,6 @@ public class SecureXMLFactoryUtil {
 
 		try {
 			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 			documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
 			documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 			documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
@@ -48,7 +47,6 @@ public class SecureXMLFactoryUtil {
 
 		try {
 			saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 			saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
 			saxParserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 			saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);

--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/SecureXMLFactoryUtil.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/SecureXMLFactoryUtil.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.core.util;
+
+import com.liferay.ide.core.LiferayCore;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.TransformerFactory;
+
+/**
+ * @author Drew Brokke
+ */
+public class SecureXMLFactoryUtil {
+
+	public static DocumentBuilderFactory newDocumentBuilderFactory() {
+		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+
+		try {
+			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
+			documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		}
+		catch (Exception exception) {
+			LiferayCore.logError("Unable to configure secure DocumentBuilderFactory", exception);
+		}
+
+		return documentBuilderFactory;
+	}
+
+	public static SAXParserFactory newSAXParserFactory() {
+		SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+
+		try {
+			saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			saxParserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		}
+		catch (Exception exception) {
+			LiferayCore.logError("Unable to configure secure SAXParserFactory", exception);
+		}
+
+		return saxParserFactory;
+	}
+
+	public static TransformerFactory newTransformerFactory() {
+		TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
+		try {
+			transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+		}
+		catch (Exception exception) {
+			LiferayCore.logError("Unable to configure secure TransformerFactory", exception);
+		}
+
+		return transformerFactory;
+	}
+
+}

--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/SecureXMLFactoryUtil.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/SecureXMLFactoryUtil.java
@@ -30,7 +30,8 @@ public class SecureXMLFactoryUtil {
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 
 		try {
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
+			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 			documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
 			documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 			documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
@@ -46,6 +47,8 @@ public class SecureXMLFactoryUtil {
 		SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
 
 		try {
+			saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 			saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
 			saxParserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 			saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
@@ -61,6 +64,7 @@ public class SecureXMLFactoryUtil {
 		TransformerFactory transformerFactory = TransformerFactory.newInstance();
 
 		try {
+			transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 			transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 			transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
 		}
@@ -69,6 +73,9 @@ public class SecureXMLFactoryUtil {
 		}
 
 		return transformerFactory;
+	}
+
+	private SecureXMLFactoryUtil() {
 	}
 
 }

--- a/tools/plugins/com.liferay.ide.hook.core/src/com/liferay/ide/hook/core/model/internal/StrutsActionPathPossibleValuesCacheService.java
+++ b/tools/plugins/com.liferay.ide.hook.core/src/com/liferay/ide/hook/core/model/internal/StrutsActionPathPossibleValuesCacheService.java
@@ -15,6 +15,7 @@
 package com.liferay.ide.hook.core.model.internal;
 
 import com.liferay.ide.core.util.FileUtil;
+import com.liferay.ide.core.util.SecureXMLFactoryUtil;
 import com.liferay.ide.hook.core.HookCore;
 
 import java.io.File;
@@ -49,9 +50,8 @@ public class StrutsActionPathPossibleValuesCacheService extends Service {
 				TreeSet<String> possibleValues = new TreeSet<>();
 
 				try {
-					DocumentBuilderFactory newInstance = DocumentBuilderFactory.newInstance();
+					DocumentBuilderFactory newInstance = SecureXMLFactoryUtil.newDocumentBuilderFactory();
 
-					newInstance.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 					newInstance.setValidating(false);
 
 					DocumentBuilder documentBuilder = newInstance.newDocumentBuilder();

--- a/tools/plugins/com.liferay.ide.portlet.core/src/com/liferay/ide/portlet/core/util/PortletModelUtil.java
+++ b/tools/plugins/com.liferay.ide.portlet.core/src/com/liferay/ide/portlet/core/util/PortletModelUtil.java
@@ -14,6 +14,8 @@
 
 package com.liferay.ide.portlet.core.util;
 
+import com.liferay.ide.core.util.SecureXMLFactoryUtil;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -102,7 +104,7 @@ public class PortletModelUtil {
 	 * @throws TransformerException
 	 */
 	public static void printDocument(Document doc, OutputStream out) throws IOException, TransformerException {
-		TransformerFactory tf = TransformerFactory.newInstance();
+		TransformerFactory tf = SecureXMLFactoryUtil.newTransformerFactory();
 
 		Transformer transformer = tf.newTransformer();
 

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/AbstractPortalBundle.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/AbstractPortalBundle.java
@@ -18,6 +18,7 @@ import com.liferay.ide.core.ILiferayConstants;
 import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.core.util.FileListing;
 import com.liferay.ide.core.util.FileUtil;
+import com.liferay.ide.core.util.SecureXMLFactoryUtil;
 import com.liferay.ide.core.util.StringPool;
 import com.liferay.ide.server.core.LiferayServerCore;
 import com.liferay.ide.server.util.JavaUtil;
@@ -189,7 +190,7 @@ public abstract class AbstractPortalBundle implements PortalBundle {
 		DocumentBuilderFactory dbf = null;
 
 		try {
-			dbf = DocumentBuilderFactory.newInstance();
+			dbf = SecureXMLFactoryUtil.newDocumentBuilderFactory();
 
 			db = dbf.newDocumentBuilder();
 

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalJBossBundle.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalJBossBundle.java
@@ -18,6 +18,7 @@ import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.core.util.FileListing;
 import com.liferay.ide.core.util.FileUtil;
 import com.liferay.ide.core.util.ListUtil;
+import com.liferay.ide.core.util.SecureXMLFactoryUtil;
 import com.liferay.ide.server.core.LiferayServerCore;
 import com.liferay.ide.server.util.JavaUtil;
 
@@ -333,7 +334,7 @@ public class PortalJBossBundle extends AbstractPortalBundle {
 		DocumentBuilderFactory dbf = null;
 
 		try {
-			dbf = DocumentBuilderFactory.newInstance();
+			dbf = SecureXMLFactoryUtil.newDocumentBuilderFactory();
 
 			db = dbf.newDocumentBuilder();
 
@@ -361,7 +362,7 @@ public class PortalJBossBundle extends AbstractPortalBundle {
 				}
 			}
 
-			TransformerFactory factory = TransformerFactory.newInstance();
+			TransformerFactory factory = SecureXMLFactoryUtil.newTransformerFactory();
 
 			Transformer transformer = factory.newTransformer();
 

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalTomcatBundle.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalTomcatBundle.java
@@ -17,6 +17,7 @@ package com.liferay.ide.server.core.portal;
 import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.core.util.FileListing;
 import com.liferay.ide.core.util.FileUtil;
+import com.liferay.ide.core.util.SecureXMLFactoryUtil;
 import com.liferay.ide.server.core.LiferayServerCore;
 import com.liferay.ide.server.core.PortalContext;
 import com.liferay.ide.server.util.ServerUtil;
@@ -366,7 +367,7 @@ public class PortalTomcatBundle extends AbstractPortalBundle {
 		DocumentBuilderFactory dbf = null;
 
 		try {
-			dbf = DocumentBuilderFactory.newInstance();
+			dbf = SecureXMLFactoryUtil.newDocumentBuilderFactory();
 
 			db = dbf.newDocumentBuilder();
 
@@ -394,7 +395,7 @@ public class PortalTomcatBundle extends AbstractPortalBundle {
 				}
 			}
 
-			TransformerFactory factory = TransformerFactory.newInstance();
+			TransformerFactory factory = SecureXMLFactoryUtil.newTransformerFactory();
 
 			Transformer transformer = factory.newTransformer();
 

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/util/ServerUtil.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/util/ServerUtil.java
@@ -24,6 +24,7 @@ import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.core.util.FileUtil;
 import com.liferay.ide.core.util.ListUtil;
 import com.liferay.ide.core.util.PropertiesUtil;
+import com.liferay.ide.core.util.SecureXMLFactoryUtil;
 import com.liferay.ide.core.workspace.LiferayWorkspaceUtil;
 import com.liferay.ide.sdk.core.ISDKConstants;
 import com.liferay.ide.sdk.core.SDK;
@@ -1105,7 +1106,7 @@ public class ServerUtil {
 		}
 
 		if (FileUtil.exists(filtersWebXmlFile)) {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilderFactory documentBuilderFactory = SecureXMLFactoryUtil.newDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 

--- a/tools/tests/com.liferay.ide.core.tests/src/com/liferay/ide/core/tests/SecureXMLFactoryUtilTests.java
+++ b/tools/tests/com.liferay.ide.core.tests/src/com/liferay/ide/core/tests/SecureXMLFactoryUtilTests.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.core.tests;
+
+import com.liferay.ide.core.util.SecureXMLFactoryUtil;
+
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import org.xml.sax.InputSource;
+
+/**
+ * @author Anthony Chu
+ */
+public class SecureXMLFactoryUtilTests extends BaseTests {
+
+	@Test
+	public void parseDoctypeXml() throws Exception {
+		String xml =
+			"<?xml version=\"1.0\"?>\n" +
+				"<!DOCTYPE struts-config PUBLIC " +
+					"\"-//Apache Software Foundation//DTD Struts Configuration 1.2//EN\" " +
+					"\"http://struts.apache.org/dtds/struts-config_1_2.dtd\">\n" +
+				"<struts-config>" +
+					"<action-mappings>" +
+						"<action path=\"/foo\"/>" +
+					"</action-mappings>" +
+				"</struts-config>";
+
+		DocumentBuilderFactory documentBuilderFactory = SecureXMLFactoryUtil.newDocumentBuilderFactory();
+
+		documentBuilderFactory.setValidating(false);
+
+		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+
+		Document document = documentBuilder.parse(new InputSource(new StringReader(xml)));
+
+		NodeList actions = document.getElementsByTagName("action");
+
+		Assert.assertEquals(1, actions.getLength());
+		Assert.assertEquals("/foo", actions.item(0).getAttributes().getNamedItem("path").getNodeValue());
+	}
+
+}

--- a/tools/tests/com.liferay.ide.core.tests/src/com/liferay/ide/core/tests/SecureXMLFactoryUtilTests.java
+++ b/tools/tests/com.liferay.ide.core.tests/src/com/liferay/ide/core/tests/SecureXMLFactoryUtilTests.java
@@ -32,7 +32,7 @@ import org.xml.sax.InputSource;
 /**
  * @author Anthony Chu
  */
-public class SecureXMLFactoryUtilTests extends BaseTests {
+public class SecureXMLFactoryUtilTests {
 
 	@Test
 	public void parseDoctypeXml() throws Exception {


### PR DESCRIPTION
[LPD-84732](https://liferay.atlassian.net/browse/LPD-84732)

Adds `SecureXMLFactoryUtil` (FEATURE_SECURE_PROCESSING + external entity/DTD access disabled) and routes all `DocumentBuilderFactory`/`SAXParserFactory`/`TransformerFactory` creations through it. SpotBugs exclusions cover the factory methods themselves.

Supersedes #431 and #441.