### PR TITLE
LPD-84732 Exclude SecureXMLFactoryUtilTests from XXE_DOCUMENT scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .apt_generated/
 .claude/*.local.json
+.claude/worktrees/
 .resources/
 .springBeans
 .tycho-consumer-pom.xml

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -156,6 +156,14 @@
 
 	<Match>
 		<Bug pattern="XXE_DOCUMENT" />
+		<Class name="com.liferay.ide.core.tests.SecureXMLFactoryUtilTests" />
+		<Method name="parseDoctypeXml" />
+	</Match>
+
+	<!-- Hardened via SecureXMLFactoryUtil; SpotBugs cannot trace features set inside the utility -->
+
+	<Match>
+		<Bug pattern="XXE_DOCUMENT" />
 		<Class name="com.liferay.ide.core.util.FileUtil" />
 		<Method name="readXML" />
 	</Match>


### PR DESCRIPTION
[LPD-84732](https://liferay.atlassian.net/browse/LPD-84732)

The test exercises `SecureXMLFactoryUtil.newDocumentBuilderFactory()`; SpotBugs can't trace the hardening through the utility.